### PR TITLE
in  toolset command Expand Environment Variables

### DIFF
--- a/PsEnv.psm1
+++ b/PsEnv.psm1
@@ -184,7 +184,7 @@ function Use-Tool {
         # Create any new variables
         if ($toolSet) {
             foreach ($key in GetJsonKeys $toolSet) {
-                $value = $toolSet.$key
+                $value = [Environment]::ExpandEnvironmentVariables($toolSet.$key)
 
                 # Actually create the variable
                 if ($value) {


### PR DESCRIPTION
I can use "%APPDATA%" in set command.

```
    "golang":
    [
    {
        "path":
        [
        "C:\\opt\\go\\bin"
        ],
        "set":
        { "GOPATH": "%APPDATA%\\gocode" }
    }
    ],
```
